### PR TITLE
sendAuthRequest接口修改为调用[WXApi sendAuthReq] 否则app store审核不过

### DIFF
--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -173,7 +173,8 @@ RCT_EXPORT_METHOD(sendAuthRequest:(NSString *)scope
         callback(@[success ? [NSNull null] : INVOKE_FAILED]);
         return;
     };
-    [WXApi sendReq:req completion:completion];
+     UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    [WXApi sendAuthReq:req viewController:rootViewController delegate:self completion:completion];
 }
 
 RCT_EXPORT_METHOD(sendSuccessResponse:(RCTResponseSenderBlock)callback)


### PR DESCRIPTION
App Store审核报：
Guideline 4.2.3 - Design - Minimum Functionality


We were required to install the WeChat app before we could log in via WeChat. Users should be able to log in with WeChat and access their accounts without having to install any additional apps.

