### PR TITLE
perf: 修改 podspec 版本号

### DIFF
--- a/RCTWeChat.podspec
+++ b/RCTWeChat.podspec
@@ -5,10 +5,13 @@
 #  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name         = "RCTWeChat"
-  s.version      = "1.9.12"
+  s.version      = package['version']
   s.summary      = "React-Native(iOS/Android) functionalities include WeChat Login, Share, Favorite and Payment {QQ: 336021910}"
   s.description  = <<-DESC
   React-Native(iOS/Android) functionalities include WeChat Login, Share, Favorite and Payment {QQ: 336021910}


### PR DESCRIPTION
现在的 .podspec 版本号是写死的，有时候 `pod install` 后不能直观看出是否升级成功；本 PR 按照官方推荐的写法，每次 package.json 版本更新后自动更新 podspec version 版本