### PR TITLE
podspec add WebKit Dependency

### DIFF
--- a/RCTWeChat.podspec
+++ b/RCTWeChat.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.dependency "React"
   s.vendored_libraries = "ios/libWeChatSDK.a"
   s.requires_arc = true
-  s.frameworks = 'SystemConfiguration','CoreTelephony'
+  s.frameworks = 'SystemConfiguration','CoreTelephony','WebKit'
   s.library = 'sqlite3','c++','z'
 end

--- a/ios/RCTWeChat.podspec
+++ b/ios/RCTWeChat.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   s.dependency "React"
   s.vendored_libraries = "libWeChatSDK.a"
-  s.ios.frameworks = 'SystemConfiguration','CoreTelephony','XCTest'
+  s.ios.frameworks = 'SystemConfiguration','CoreTelephony','XCTest','WebKit'
   s.ios.library = 'sqlite3','c++','z'
 
 end


### PR DESCRIPTION
修复微信 SDK 缺少 WebKit.framework 库的 BUG
 
报错信息：
> Undefined symbols for architecture x86_64:
> "OBJC_CLASS_WKWebViewConfiguration", referenced from:
> objc-class-ref in libWeChatSDK.a(WapAuthHandler.o)
> ld: symbol(s) not found for architecture x86_64
> clang: error: linker command failed with exit code 1 (use -v to see invocation)