### PR TITLE
fix(android): reduce local image share memory usage

### DIFF
--- a/android/src/main/java/com/wechatlib/WeChatLibModule.java
+++ b/android/src/main/java/com/wechatlib/WeChatLibModule.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
-import android.os.Environment;
 import android.util.Base64;
 
 import androidx.annotation.Nullable;
@@ -65,10 +64,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -94,24 +89,32 @@ public class WeChatLibModule extends ReactContextBaseJavaModule implements IWXAP
     }
 
     private static byte[] bitmapResizeGetBytes(Bitmap image, int size) {
-        // little-snow-fox 2019.10.20
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        // 质量压缩方法，这里100表示第一次不压缩，把压缩后的数据缓存到 baos
-        image.compress(Bitmap.CompressFormat.JPEG, 100, baos);
-        int options = 100;
-        // 循环判断压缩后依然大于 32kb 则继续压缩
-        while (baos.toByteArray().length / 1024 > size) {
-            // 重置baos即清空baos
-            baos.reset();
-            if (options > 10) {
-                options -= 8;
-            } else {
-                return bitmapResizeGetBytes(Bitmap.createScaledBitmap(image, 280, image.getHeight() / image.getWidth() * 280, true), size);
+        Bitmap thumbnail = null;
+        try {
+            int maxDimension = 150;
+            int width = image.getWidth();
+            int height = image.getHeight();
+
+            float scale = Math.min(1.0f, Math.min((float) maxDimension / width, (float) maxDimension / height));
+            int targetWidth = Math.max(1, (int) (width * scale));
+            int targetHeight = Math.max(1, (int) (height * scale));
+
+            thumbnail = Bitmap.createScaledBitmap(image, targetWidth, targetHeight, true);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            thumbnail.compress(Bitmap.CompressFormat.JPEG, 75, baos);
+
+            if (baos.toByteArray().length / 1024 > size) {
+                baos.reset();
+                thumbnail.compress(Bitmap.CompressFormat.JPEG, 50, baos);
             }
-            // 这里压缩options%，把压缩后的数据存放到baos中
-            image.compress(Bitmap.CompressFormat.JPEG, options, baos);
+
+            return baos.toByteArray();
+        } finally {
+            if (thumbnail != null && thumbnail != image) {
+                thumbnail.recycle();
+            }
         }
-        return baos.toByteArray();
     }
 
     public WeChatLibModule(ReactApplicationContext context) {
@@ -414,57 +417,53 @@ public class WeChatLibModule extends ReactContextBaseJavaModule implements IWXAP
      */
     @ReactMethod
     public void shareLocalImage(final ReadableMap data, final Callback callback) {
-        FileInputStream fs = null;
+        Bitmap bmp = null;
         try {
             String path = data.getString("imageUrl");
             if (path.indexOf("file://") > -1) {
                 path = path.substring(7);
             }
-//            int maxWidth = data.hasKey("maxWidth") ? data.getInt("maxWidth") : -1;
-            fs = new FileInputStream(path);
-            Bitmap bmp = BitmapFactory.decodeStream(fs);
 
-//            if (maxWidth > 0) {
-//                bmp = Bitmap.createScaledBitmap(bmp, maxWidth, bmp.getHeight() / bmp.getWidth() * maxWidth, true);
-//            }
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = true;
+            BitmapFactory.decodeFile(path, options);
 
-//            File f = Environment.getExternalStoragePublicDirectory(SDCARD_ROOT + "/react-native-wechat-lib");
-//            String fileName = "wechat-share.jpg";
-//            String tempPath = SDCARD_ROOT + "/react-native-wechat-lib";
-//            File file = new File(f, fileName);
-//            try {
-//                FileOutputStream fos = new FileOutputStream(file);
-//                bmp.compress(Bitmap.CompressFormat.JPEG, 100, fos);
-//                fos.flush();
-//                fos.close();
-//            } catch (FileNotFoundException e) {
-//                e.printStackTrace();
-//            } catch (IOException e) {
-//                e.printStackTrace();
-//            }
+            int width = options.outWidth;
+            int height = options.outHeight;
+            long totalPixels = (long) width * height;
+            long maxPixels = 2048L * 2048L;
 
-//            int size = bmp.getByteCount();
-//            ByteArrayOutputStream var2 = new ByteArrayOutputStream();
-//            bmp.compress(Bitmap.CompressFormat.JPEG, 85, var2);
-//            int size2 = var2.toByteArray().length;
-            // 初始化 WXImageObject 和 WXMediaMessage 对象
+            int inSampleSize = 1;
+            if (totalPixels > maxPixels) {
+                inSampleSize = (int) Math.ceil(Math.sqrt((double) totalPixels / maxPixels));
+            }
+
+            options.inJustDecodeBounds = false;
+            options.inSampleSize = inSampleSize;
+            bmp = BitmapFactory.decodeFile(path, options);
+
+            if (bmp == null) {
+                callback.invoke("decode image failed", false);
+                return;
+            }
 
             WXImageObject imgObj = new WXImageObject(bmp);
             WXMediaMessage msg = new WXMediaMessage();
             msg.mediaObject = imgObj;
-            // 设置缩略图
             msg.thumbData = bitmapResizeGetBytes(bmp, THUMB_SIZE);
-            bmp.recycle();
-            // 构造一个Req
+
             SendMessageToWX.Req req = new SendMessageToWX.Req();
             req.transaction = "img";
             req.message = msg;
-            // req.userOpenId = getOpenId();
             req.scene = data.hasKey("scene") ? data.getInt("scene") : SendMessageToWX.Req.WXSceneSession;
             callback.invoke(null, api.sendReq(req));
-        } catch (FileNotFoundException e) {
-            callback.invoke(null, false);
+        } catch (Exception e) {
+            callback.invoke(e.getMessage(), false);
             e.printStackTrace();
+        } finally {
+            if (bmp != null) {
+                bmp.recycle();
+            }
         }
     }
 


### PR DESCRIPTION
## 背景

Android 端 `shareLocalImage` 目前会直接把本地图片完整 decode 成 `Bitmap`，如果用户选择了较大的照片，容易在分享前触发较高的内存占用，严重时可能 OOM。

另外缩略图生成逻辑会反复对原图做 JPEG 压缩，并在压不下去时递归缩放。对于大图来说，这个过程也会额外放大内存压力。

## 改动

- `shareLocalImage` 在 decode 本地图片前先读取图片尺寸，并根据约 `2048 * 2048` 的像素上限计算 `inSampleSize`。
- 超过像素上限的大图会先降采样后再分享，避免直接完整 decode 超大图片。
- 缩略图生成时先把图片缩到最大边不超过 150px，再做 JPEG 压缩。
- 小图不会被放大，只有超过 150px 的图片才会缩小。
- 在 `finally` 中回收 `Bitmap`，减少分享完成或失败后的内存占用。
- 清理了 `shareLocalImage` 中已经注释掉的旧文件写入逻辑和不再使用的 import。

## 行为说明

这个改动会对 Android 本地图片分享中的超大图片做降采样处理。这样可以显著降低内存峰值，但对超大图片来说，分享出去的图片分辨率会被限制在约 4MP 以内。

考虑到当前实现本身就是通过 `WXImageObject(Bitmap)` 分享图片，而不是直接把原始文件路径交给微信，这里优先保证大图分享时的稳定性，避免因为完整 decode 原图导致应用崩溃。

## 验证

- 已执行 `git diff --check`，没有空白或格式问题。
- 尝试在 `example/android` 执行：

```sh
GRADLE_USER_HOME=/private/tmp/gradle-home ./gradlew :app:compileDebugJavaWithJavac
```

该命令未能进入 Java 编译阶段，失败原因是 example 工程当前没有解析到 `com.facebook.react:react-native:+` 和 `com.facebook.react:hermes-engine:+`，属于 example 的 React Native 本地 Maven 依赖解析问题。
